### PR TITLE
Null deref in kernel with USB webcams.

### DIFF
--- a/drivers/usb/core/usb.c
+++ b/drivers/usb/core/usb.c
@@ -272,9 +272,13 @@ EXPORT_SYMBOL_GPL(usb_find_alt_setting);
 struct usb_interface *usb_ifnum_to_if(const struct usb_device *dev,
 				      unsigned ifnum)
 {
-	struct usb_host_config *config = dev->actconfig;
+	struct usb_host_config *config = NULL;
 	int i;
 
+	if (!dev)
+		return NULL;
+	
+	config = dev->actconfig;
 	if (!config)
 		return NULL;
 	for (i = 0; i < config->desc.bNumInterfaces; i++)


### PR DESCRIPTION
There is some kind of race condition affecting Logitech webcams that crash USB with a null dereference.  Affects raspberry pi devices as well. No check on dev before dereference.  Simple fix.

Signed-off-by: John Boero <boeroboy@gmail.com>

https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1827452
https://github.com/raspberrypi/linux/issues/2551

[ 5312.470363] BUG: kernel NULL pointer dereference, address: 0000000000000000
[ 5312.470370] #PF: supervisor read access in kernel mode
[ 5312.470372] #PF: error_code(0x0000) - not-present page
[ 5312.470374] PGD 8000001a1f7c2067 P4D 8000001a1f7c2067 PUD 0 
[ 5312.470380] Oops: 0000 [#1] SMP PTI
[ 5312.470385] CPU: 18 PID: 47381 Comm: v4l2src0:src Tainted: P           OE     5.8.18-200.fc32.x86_64 #1
[ 5312.470387] Hardware name: Hewlett-Packard HP Z640 Workstation/212A, BIOS M60 v02.50 11/07/2019
[ 5312.470394] RIP: 0010:usb_ifnum_to_if+0x3a/0x50
[ 5312.470398] Code: 34 41 0f b6 50 04 84 d2 74 2f 83 ea 01 49 8d 80 98 00 00 00 49 8d 8c d0 a0 00 00 00 eb 09 48 83 c0 08 48 39 c8 74 12 4c 8b 00 <49> 8b 10 0f b6 52 02 39 f2 75 e9 4c 89 c0 c3 45 31 c0 4c 89 c0 c3
[ 5312.470401] RSP: 0018:ffffac3683143bb0 EFLAGS: 00010206
[ 5312.470404] RAX: ffff8d63f1463498 RBX: 0000000000000000 RCX: ffff8d63f14634b8
[ 5312.470406] RDX: 0000000000000003 RSI: 0000000000000001 RDI: ffff8d63fda0f000
[ 5312.470408] RBP: ffff8d63f8f15398 R08: 0000000000000000 R09: ffffffff98bca248
[ 5312.470409] R10: ffff8d6407531328 R11: 0000000000000000 R12: ffff8d63f8f15398
[ 5312.470411] R13: ffff8d63fda0f000 R14: ffff8d63fda0f000 R15: ffff8d640851a000
[ 5312.470415] FS:  00007ff500ff9700(0000) GS:ffff8d640f880000(0000) knlGS:0000000000000000
[ 5312.470417] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[ 5312.470419] CR2: 0000000000000000 CR3: 0000001a1e700004 CR4: 00000000001606e0
[ 5312.470421] Call Trace:
[ 5312.470430]  usb_hcd_alloc_bandwidth+0x23d/0x360
[ 5312.470438]  usb_set_interface+0x120/0x360
[ 5312.470452]  uvc_video_start_transfer+0x19c/0x4f0 [uvcvideo]
[ 5312.470461]  uvc_video_start_streaming+0x7b/0xd0 [uvcvideo]
[ 5312.470467]  uvc_start_streaming+0x2d/0xf0 [uvcvideo]
[ 5312.470478]  vb2_start_streaming+0x63/0x100 [videobuf2_common]
[ 5312.470484]  vb2_core_streamon+0x54/0xb0 [videobuf2_common]
[ 5312.470490]  uvc_queue_streamon+0x2a/0x40 [uvcvideo]
[ 5312.470496]  uvc_ioctl_streamon+0x3a/0x60 [uvcvideo]
[ 5312.470518]  __video_do_ioctl+0x377/0x3b0 [videodev]
[ 5312.470529]  ? do_futex+0x87d/0xcb0
[ 5312.470534]  ? __mod_lruvec_state+0x41/0xf0
[ 5312.470544]  video_usercopy+0x177/0x570 [videodev]
[ 5312.470555]  ? v4l_reqbufs+0x60/0x60 [videodev]
[ 5312.470560]  ? selinux_file_ioctl+0x122/0x1c0
[ 5312.470570]  v4l2_ioctl+0x48/0x50 [videodev]
[ 5312.470577]  ksys_ioctl+0x82/0xc0
[ 5312.470581]  __x64_sys_ioctl+0x16/0x20
[ 5312.470588]  do_syscall_64+0x4d/0x90
[ 5312.470593]  entry_SYSCALL_64_after_hwframe+0x44/0xa9
[ 5312.470598] RIP: 0033:0x7ff52a45e3bb
[ 5312.470602] Code: 0f 1e fa 48 8b 05 dd aa 0c 00 64 c7 00 26 00 00 00 48 c7 c0 ff ff ff ff c3 66 0f 1f 44 00 00 f3 0f 1e fa b8 10 00 00 00 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d ad aa 0c 00 f7 d8 64 89 01 48
[ 5312.470604] RSP: 002b:00007ff500ff88f8 EFLAGS: 00000246 ORIG_RAX: 0000000000000010
[ 5312.470607] RAX: ffffffffffffffda RBX: 00007ff4e4026260 RCX: 00007ff52a45e3bb
[ 5312.470609] RDX: 000056430202cff0 RSI: 0000000040045612 RDI: 0000000000000027
[ 5312.470611] RBP: 000056430202cfe0 R08: 00000000000005e7 R09: 0000000000000000
[ 5312.470613] R10: 00000000fffffffe R11: 0000000000000246 R12: 0000000000000000
[ 5312.470614] R13: 0000000000000004 R14: 00007ff4e400c8c0 R15: 0000000000000001
[ 5312.470618] Modules linked in: snd_seq_dummy snd_hrtimer rfcomm xt_CHECKSUM xt_MASQUERADE xt_conntrack ipt_REJECT nf_nat_tftp nft_objref nf_conntrack_tftp tun bridge stp llc rpcsec_gss_krb5 auth_rpcgss nfsv4 dns_resolver nfs lockd grace fscache nft_fib_inet nft_fib_ipv4 nft_fib_ipv6 nft_fib nft_reject_inet nf_reject_ipv4 nf_reject_ipv6 nft_reject nft_ct nft_chain_nat ip6table_nat ip6table_mangle ip6table_raw ip6table_security iptable_nat nf_nat nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 iptable_mangle iptable_raw iptable_security vboxnetadp(OE) vboxnetflt(OE) vboxdrv(OE) ip_set nf_tables nfnetlink ip6table_filter ip6_tables iptable_filter overlay cmac bnep lm75 rpcrdma sunrpc ib_isert iscsi_target_mod ib_iser libiscsi scsi_transport_iscsi ib_srpt target_core_mod xfs ib_srp scsi_transport_srp ib_ipoib rdma_ucm vfat fat squashfs ib_umad rdma_cm loop ib_cm iw_cm btusb btrtl btbcm btintel bluetooth intel_rapl_msr intel_rapl_common ecdh_generic ecc sb_edac x86_pkg_temp_thermal intel_powerclamp
[ 5312.470671]  snd_hda_codec_realtek coretemp snd_hda_codec_generic snd_hda_codec_hdmi ledtrig_audio kvm_intel snd_hda_intel snd_intel_dspcfg dm_cache_smq ocrdma uvcvideo snd_hda_codec snd_usb_audio kvm videobuf2_vmalloc iTCO_wdt ucsi_ccg intel_pmc_bxt typec_ucsi snd_hda_core typec snd_usbmidi_lib ib_uverbs videobuf2_memops nvidia_drm(POE) iTCO_vendor_support pktcdvd nvidia_modeset(POE) irqbypass dm_cache snd_hwdep snd_rawmidi videobuf2_v4l2 rapl videobuf2_common intel_cstate dm_persistent_data nvidia_uvm(OE) ib_core dm_bio_prison snd_seq snd_seq_device intel_uncore hp_wmi videodev joydev pcspkr sparse_keymap snd_pcm wmi_bmof mc rfkill snd_timer i2c_i801 nvidia(POE) i2c_smbus lpc_ich snd soundcore i2c_nvidia_gpu tpm_infineon binfmt_misc nbd ip_tables amdgpu iommu_v2 gpu_sched i2c_algo_bit ttm drm_kms_helper crct10dif_pclmul crc32_pclmul crc32c_intel cec ghash_clmulni_intel drm serio_raw nvme e1000e be2net nvme_core wmi fuse
[ 5312.470722] CR2: 0000000000000000
[ 5312.470726] ---[ end trace 1df6e1f93d1754fc ]---
[ 5312.470729] RIP: 0010:usb_ifnum_to_if+0x3a/0x50
[ 5312.470732] Code: 34 41 0f b6 50 04 84 d2 74 2f 83 ea 01 49 8d 80 98 00 00 00 49 8d 8c d0 a0 00 00 00 eb 09 48 83 c0 08 48 39 c8 74 12 4c 8b 00 <49> 8b 10 0f b6 52 02 39 f2 75 e9 4c 89 c0 c3 45 31 c0 4c 89 c0 c3
[ 5312.470734] RSP: 0018:ffffac3683143bb0 EFLAGS: 00010206
[ 5312.470737] RAX: ffff8d63f1463498 RBX: 0000000000000000 RCX: ffff8d63f14634b8
[ 5312.470739] RDX: 0000000000000003 RSI: 0000000000000001 RDI: ffff8d63fda0f000
[ 5312.470740] RBP: ffff8d63f8f15398 R08: 0000000000000000 R09: ffffffff98bca248
[ 5312.470742] R10: ffff8d6407531328 R11: 0000000000000000 R12: ffff8d63f8f15398
[ 5312.470744] R13: ffff8d63fda0f000 R14: ffff8d63fda0f000 R15: ffff8d640851a000
[ 5312.470747] FS:  00007ff500ff9700(0000) GS:ffff8d640f880000(0000) knlGS:0000000000000000
[ 5312.470749] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[ 5312.470751] CR2: 0000000000000000 CR3: 0000001a1e700004 CR4: 00000000001606e0